### PR TITLE
feat/버튼 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
+    "clsx": "^2.1.1",
     "next": "14.2.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.4)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 14.2.7
         version: 14.2.7(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1186,6 +1189,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -4004,6 +4011,8 @@ snapshots:
       fsevents: 2.3.3
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,9 +1,14 @@
+import clsx from 'clsx';
 import { ButtonHTMLAttributes } from 'react';
 
-type ButtonVariant = 'main' | 'wide' | 'default';
+type ButtonVariant = 'main' | 'wide' | 'round';
+type ButtonSize = 'sm' | 'md';
+type ButtonColor = 'primary' | 'white' | 'blue';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant: ButtonVariant;
+  size: ButtonSize;
+  color: ButtonColor;
 }
 
 export default function Button({
@@ -13,11 +18,20 @@ export default function Button({
   form,
   onClick,
   disabled = false,
-  variant = 'default',
+  variant = 'main',
+  size = 'md',
+  color = 'primary',
 }: ButtonProps) {
+  const buttonStyle = clsx(
+    'flex-center',
+    styleByVariant[variant],
+    styleByColor[color],
+    size === 'sm' && smButtonStyle,
+    className
+  );
   return (
     <button
-      className={className}
+      className={buttonStyle}
       type={type}
       form={form}
       onClick={onClick}
@@ -28,8 +42,27 @@ export default function Button({
   );
 }
 
+const baseStyle = 'rounded-xl font-semibold';
+
 const styleByVariant: Record<ButtonVariant, string> = {
-  main: '',
-  wide: '',
-  default: '',
+  main: clsx(
+    baseStyle,
+    'w-112 h-48 md:w-136 md:h-56 xl:w-286 xl:h-64 text-16 leading-26 md:text-20 md:leading-32'
+  ),
+  wide: clsx(
+    baseStyle,
+    'w-full h-44 xl:h-64 text-16 leading-26 xl:text-20 xl:leading-32'
+  ),
+  round:
+    'h-48 xl:h-56 px-18 xl:px-40 text-14 font-medium leading-24 xl:text-20 xl:leading-32',
 };
+
+const styleByColor: Record<ButtonColor, string> = {
+  primary:
+    'bg-black-500 text-blue-100 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-300 disabled:outline disabled:outline-blue-100',
+  white: 'bg-background-100 border border-line-200 text-blue-500',
+  blue: 'bg-blue-900 text-blue-100',
+};
+
+const smButtonStyle =
+  'w-auto px-16 h-32 md:h-44 text-12 leading-20 md:text-16 md:leading-26';

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,24 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export default function Button({
+  children,
+  className = '',
+  type = 'button',
+  form,
+  onClick,
+  disabled = false,
+}: ButtonProps) {
+  return (
+    <button
+      className={className}
+      type={type}
+      form={form}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,9 +6,9 @@ type ButtonSize = 'sm' | 'md';
 type ButtonColor = 'primary' | 'white' | 'blue';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant: ButtonVariant;
-  size: ButtonSize;
-  color: ButtonColor;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  color?: ButtonColor;
 }
 
 export default function Button({
@@ -54,7 +54,7 @@ const styleByVariant: Record<ButtonVariant, string> = {
     'w-full h-44 xl:h-64 text-16 leading-26 xl:text-20 xl:leading-32'
   ),
   round:
-    'h-48 xl:h-56 px-18 xl:px-40 text-14 font-medium leading-24 xl:text-20 xl:leading-32',
+    'rounded-full h-48 xl:h-56 px-18 xl:px-40 text-14 font-medium leading-24 xl:text-20 xl:leading-32',
 };
 
 const styleByColor: Record<ButtonColor, string> = {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -59,7 +59,7 @@ const styleByVariant: Record<ButtonVariant, string> = {
 
 const styleByColor: Record<ButtonColor, string> = {
   primary:
-    'bg-black-500 text-blue-100 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-300 disabled:outline disabled:outline-blue-100',
+    'bg-black-500 text-blue-100 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-300 disabled:outline disabled:outline-blue-100 disabled:cursor-not-allowed',
   white: 'bg-background-100 border border-line-200 text-blue-500',
   blue: 'bg-blue-900 text-blue-100',
 };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -27,3 +27,9 @@ export default function Button({
     </button>
   );
 }
+
+const styleByVariant: Record<ButtonVariant, string> = {
+  main: '',
+  wide: '',
+  default: '',
+};

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,10 @@
 import { ButtonHTMLAttributes } from 'react';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+type ButtonVariant = 'main' | 'wide' | 'default';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant: ButtonVariant;
+}
 
 export default function Button({
   children,
@@ -9,6 +13,7 @@ export default function Button({
   form,
   onClick,
   disabled = false,
+  variant = 'default',
 }: ButtonProps) {
   return (
     <button

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.flex-center {
+  @apply flex items-center justify-center;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolved:#3

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

공용 컴포넌트  버튼 만들었습니다.
- 클래스명 병합 라이브러리 clsx 설치했습니다.
- twMerge 는 창기 님께서 설치하신다고 하셔서, 그 부분은 남겨 두었습니다.
- 색상이랑 버튼의 variant 을 props 로 넘겨서 변경 가능하게 했습니다.
- 이거로 구현 못하는 버튼은 className 넘겨서 직접 커스텀해야 합니다.
- 사이즈 같은 경우에 특이하게 main 버튼 중에 32px 인 친구들 보여서, 메인 버튼 중에 작은 애들 구별하려고 sm 속성에만 스타일링 다르게 주었습니다.

![image](https://github.com/user-attachments/assets/8dfd6246-af99-48d2-a727-716a86ec11de)

### 스크린샷 (선택)

```tsx
      <Button>기본 버튼</Button>
```

![기본 버튼](https://github.com/user-attachments/assets/6b2f9e55-2e55-469a-b366-cc3ec928d91c)

```tsx
      <Button variant='round' color='white'>
        둥근 버튼
      </Button>
```

<img width="258" alt="image" src="https://github.com/user-attachments/assets/2410b440-09cf-4a9d-a119-c41bb4c231a4">


```tsx
      <Button variant='wide' color='blue'>
        긴 버튼
      </Button>
```
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/0d251a1b-9056-48e9-aa5f-25a0d857c39b">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 버튼 컴포넌트를 직접 사용하신다고 할 때, 불편할 것으로 예상되는 점이나 이해가지 않는 부분을 말씀해주세요 !
