### PR TITLE
feat/feed페이지 퍼블리싱

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -9,8 +9,8 @@ module.exports = {
   bracketSpacing: true,
   arrowParens: 'avoid',
   plugins: [
-    'prettier-plugin-tailwindcss',
     '@trivago/prettier-plugin-sort-imports',
+    'prettier-plugin-tailwindcss',
   ],
   importOrder: ['^@core/(.*)$', '^@server/(.*)$', '^@ui/(.*)$', '^[./]'],
   importOrderSeparation: true,

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,6 +1,8 @@
+import Up from '@/assets/icons/ic-down-chevron.svg';
 import Plus from '@/assets/icons/ic-plus.svg';
 import Button from '@/components/Button';
 import Card from '@/shared/Card';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 const mockDataArray = [
@@ -29,6 +31,12 @@ const mockDataArray = [
 ];
 
 export default function Feed() {
+  const router = useRouter();
+
+  const handleAddEpigramButtonClick = () => {
+    if (router.pathname === '/addepigram') return;
+    router.push('/addepigram');
+  };
   const [data, setData] = useState<
     { content: string; author: string; tags: string[] }[]
   >([]);
@@ -59,7 +67,20 @@ export default function Feed() {
       <div className='pt:56 flex items-center justify-center pb-114 xl:pt-80'>
         <Button variant='round' color='white'>
           <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
-          에피그램더보기
+          에피그램 더보기
+        </Button>
+      </div>
+      <div className='fixed bottom-152 right-120'>
+        <Button
+          variant='round'
+          onClick={handleAddEpigramButtonClick}
+          color='blue'
+        >
+          <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
+          에피그램 만들기
+        </Button>
+        <Button color='blue' variant='round'>
+          <Up className='h-24 w-24 text-white' />
         </Button>
       </div>
     </div>

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,0 +1,59 @@
+import Card from '@/shared/Card';
+import { useEffect, useState } from 'react';
+
+const mockDataArray = [
+  { content: '명언 1입니다', author: 'Author One', tags: ['첫번째'] },
+  {
+    content: `Your work is going to fill a large part of your life, and the only way to be truly satisfied is to do what you believe is great work. And the only way to do great work is to love what you do. If you haven't found it yet, keep looking. Don't settle. As with all matters of the heart, you'll know when you find it`,
+    author: 'Steve Jobs',
+    tags: ['긴 명언 테스트', '스크롤로 표시?', '그냥 길어지도록?'],
+  },
+  {
+    content:
+      'If you cannot fly then run. If you cannot run, then walk. And, if you cannot walk, then crawl, but whatever you do, you have to keep moving forward.',
+    author: 'Martin Luther King Jr',
+    tags: ['태그2', '태그4'],
+  },
+  {
+    content: 'Yet another piece of mock content',
+    author: 'Author Three',
+    tags: ['태그3'],
+  },
+  {
+    content: 'Yet another piece of mock content',
+    author: 'Author Three',
+    tags: ['태그4'],
+  },
+];
+
+export default function Feed() {
+  const [data, setData] = useState<
+    { content: string; author: string; tags: string[] }[]
+  >([]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setData(mockDataArray);
+    }, 500);
+  }, []);
+
+  return (
+    <div className='h-full w-full bg-background-100'>
+      <div className='px-24 md:px-72 xl:px-360'>
+        <h1 className='pb-24 pt-32 font-primary text-24 font-semibold md:pb-40 md:pt-120 md:leading-32'>
+          피드
+        </h1>
+        <div className='grid grid-cols-1 gap-x-8 gap-y-16 md:grid-cols-2 md:gap-x-12 md:gap-y-24 xl:gap-x-30 xl:gap-y-40'>
+          {data.map((item, index) => (
+            <Card
+              key={index}
+              content={item.content}
+              author={item.author}
+              tags={item.tags.map(tag => `#${tag} `)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,3 +1,5 @@
+import Plus from '@/assets/icons/ic-plus.svg';
+import Button from '@/components/Button';
 import Card from '@/shared/Card';
 import { useEffect, useState } from 'react';
 
@@ -53,6 +55,12 @@ export default function Feed() {
             />
           ))}
         </div>
+      </div>
+      <div className='pt:56 flex items-center justify-center pb-114 xl:pt-80'>
+        <Button variant='round' color='white'>
+          <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
+          에피그램더보기
+        </Button>
       </div>
     </div>
   );

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -37,6 +37,12 @@ export default function Feed() {
     if (router.pathname === '/addepigram') return;
     router.push('/addepigram');
   };
+  const handlePageUp = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
   const [data, setData] = useState<
     { content: string; author: string; tags: string[] }[]
   >([]);
@@ -81,7 +87,7 @@ export default function Feed() {
             <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
             에피그램 만들기
           </Button>
-          <Button color='blue' variant='round'>
+          <Button onClick={handlePageUp} color='blue' variant='round'>
             <Up className='h-24 w-24 rotate-180' />
           </Button>
         </div>

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -70,18 +70,21 @@ export default function Feed() {
           에피그램 더보기
         </Button>
       </div>
-      <div className='fixed bottom-152 right-120'>
-        <Button
-          variant='round'
-          onClick={handleAddEpigramButtonClick}
-          color='blue'
-        >
-          <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
-          에피그램 만들기
-        </Button>
-        <Button color='blue' variant='round'>
-          <Up className='h-24 w-24 text-white' />
-        </Button>
+      <div className='fixed bottom-104 right-24 md:bottom-92 md:right-72 xl:bottom-80 xl:right-120'>
+        <div className='grid justify-items-end'>
+          <Button
+            variant='round'
+            onClick={handleAddEpigramButtonClick}
+            color='blue'
+            className='mb-8'
+          >
+            <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
+            에피그램 만들기
+          </Button>
+          <Button color='blue' variant='round'>
+            <Up className='h-24 w-24 rotate-180' />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/shared/Card.tsx
+++ b/src/shared/Card.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+interface CardProps {
+  content: string;
+  author: string;
+  tags: string[];
+}
+
+export default function Card({ content, author, tags }: CardProps) {
+  return (
+    <div className='font-secondary'>
+      <div className='bg-stripe-pattern bg-stripe-size mb-8 flex min-h-295 flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23'>
+        <div className='flex-1'>
+          <div className='text-14 font-normal leading-24 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+            {content}
+          </div>
+        </div>
+        <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+          - {author} -
+        </div>
+      </div>
+      {/* TODO: tag 컴포넌트 연결 */}
+      <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+        {tags}
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -107,6 +107,13 @@ const config: Config = {
         primary: ['Pretendard', 'sans-serif'],
         secondary: ['Iropke Batang', 'serif'],
       },
+      backgroundImage: {
+        'stripe-pattern':
+          'linear-gradient(to bottom, #f2f2f2 1px, transparent 1px)',
+      },
+      backgroundSize: {
+        'stripe-size': '100% 24px',
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -90,6 +90,7 @@ const config: Config = {
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/shared/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 #19 

## 📝 작업 내용
### Card 컴포넌트 구현 , Feed 페이지 퍼블리싱

- content, author, tag를 props로 전달하면 카드가 만들어집니다.
- 카드 하단의 #{tag}는 추후에 chip컴포넌트 import 하는 방식으로 수정할 예정입니다.
- tailwind.config.ts에 카드 줄무늬 배경 패턴에 사용하는 tailwind 코드 추가했습니다
```
backgroundImage: {
        'stripe-pattern':
          'linear-gradient(to bottom, #f2f2f2 1px, transparent 1px)',
      },
      backgroundSize: {
        'stripe-size': '100% 24px',
      },
```
줄무늬 배경 패턴을 적용하려면 아래와 같이 className을 적용하시면 됩니다
```
className='bg-stripe-pattern bg-stripe-size'
```


### 스크린샷 (선택)
### 1) 카드 컴포넌트
![스크린샷 2024-09-06 오전 2 44 57](https://github.com/user-attachments/assets/415012ee-1deb-4cc6-984b-e8fce17da104)

### 2) 반응형
![feed02](https://github.com/user-attachments/assets/f5372099-5ccd-4631-90b4-05e42a650c66)

### 3) 페이지 맨 위로 이동하는 버튼
![2scroll](https://github.com/user-attachments/assets/381c1c4c-9adf-49d0-899e-33e13a278f37)

### 4)  '+ 에피그램 만들기' 클릭 -> /addEpigram 으로 이동
![2addPage](https://github.com/user-attachments/assets/896eafc4-eaa8-4fcd-b3e7-e52a26da0579)


## 💬리뷰 요구사항(선택)

