### PR TITLE
feat/signin form, signup form 완성

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
     "clsx": "^2.1.1",
+    "es-hangul": "^2.1.0",
     "next": "14.2.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      es-hangul:
+        specifier: ^2.1.0
+        version: 2.1.0
       next:
         specifier: 14.2.7
         version: 14.2.7(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1419,6 +1422,9 @@ packages:
 
   es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+
+  es-hangul@2.1.0:
+    resolution: {integrity: sha512-Ka10Um476t1t7NtOXxeLb6RCAmPQGisMsQjDxqhc7zHIuL2APtcR2Lp6SRNW9XVb1VcnX+en7WMmKkjRurRbow==}
 
   es-iterator-helpers@1.0.19:
     resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
@@ -4426,6 +4432,8 @@ snapshots:
       isarray: 2.0.5
       stop-iteration-iterator: 1.0.0
 
+  es-hangul@2.1.0: {}
+
   es-iterator-helpers@1.0.19:
     dependencies:
       call-bind: 1.0.7
@@ -4477,7 +4485,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -4508,7 +4516,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -4526,7 +4534,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -53,7 +53,7 @@ function Label({ children, className }: LabelProps) {
 
 function LabelHeader({ children, className }: BaseProps) {
   const headerClass = cn(
-    'mb-16 text-14 font-medium leading-24 text-blue-900 md:mb-20 md:text-16 md:leading-26 xl:text-20 xl:leading-32',
+    'text-14 font-medium leading-24 text-blue-900 md:text-16 md:leading-26 xl:text-20 xl:leading-32',
     className
   );
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -74,6 +74,7 @@ function Input({ className, name, ...rest }: InputProps) {
     { 'outline outline-1 outline-error': !!errors[name] },
     className
   );
+  const placeholder = rest.placeholder ? rest.placeholder : name;
 
   return (
     <>
@@ -81,7 +82,7 @@ function Input({ className, name, ...rest }: InputProps) {
         {...register(name, VALIDATION_RULES[name])}
         className={inputClass}
         {...rest}
-        placeholder={name}
+        placeholder={placeholder}
       />
       {errors[name] && (
         <ErrorMessage className=''>{String(errors[name].message)}</ErrorMessage>
@@ -117,8 +118,8 @@ function PasswordInput({ className, name, ...rest }: InputProps) {
   const placeholder = rest.placeholder ? rest.placeholder : name;
 
   const registerOptions =
-    name === '비밀번호 확인'
-      ? PASSWORD_CONFIRM_RULES(getValues('비밀번호'))
+    name === 'passwordConfirmation'
+      ? PASSWORD_CONFIRM_RULES(getValues('password'))
       : VALIDATION_RULES[name];
 
   return (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -30,7 +30,7 @@ interface BaseProps {
 export default function Form({ onSubmit, id, className, children }: FormProps) {
   const methods = useForm();
 
-  const formClass = cn('w-full md:max-w-384 xl:max-w-640', className);
+  const formClass = cn('', className);
 
   return (
     <FormProvider {...methods}>
@@ -46,7 +46,7 @@ export default function Form({ onSubmit, id, className, children }: FormProps) {
 }
 
 function Label({ children, className }: LabelProps) {
-  const labelClass = cn('mb-20 md:mb-40  block', className);
+  const labelClass = cn('block', className);
 
   return <label className={labelClass}> {children} </label>;
 }

--- a/src/constants/formValidation.ts
+++ b/src/constants/formValidation.ts
@@ -1,19 +1,26 @@
 import { RegisterOptions } from 'react-hook-form';
 
-export type Field = '이메일' | '비밀번호' | '비밀번호 확인' | '닉네임';
+export type Field = 'email' | 'password' | 'passwordConfirmation' | 'nickname';
 
+const FIELD_DICTIONARY: Record<Field, string> = {
+  email: '이메일',
+  password: '비밀번호',
+  passwordConfirmation: '비밀번호 확인',
+  nickname: '닉네임',
+};
 const EMAIL_PATTERN = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const PASSWORD_PATTERN = /^[A-Za-z\d!@#$%^&*]+$/;
 const MAX_NICKNAME_LENGTH = 20;
 const MIN_PASSWORD_LENGTH = 8;
 
 const generateRequiredMessage = (name: Field): string => {
-  if (name === '비밀번호 확인') return `${name}을 입력해주세요.`;
-  return `${name}은/는 필수 입력입니다.`;
+  if (name === 'passwordConfirmation')
+    return `${FIELD_DICTIONARY[name]}을 입력해주세요.`;
+  return `${FIELD_DICTIONARY[name]}은/는 필수 입력입니다.`;
 };
 
 const EMAIL_RULES: RegisterOptions = {
-  required: generateRequiredMessage('이메일'),
+  required: generateRequiredMessage('email'),
   pattern: {
     value: EMAIL_PATTERN,
     message: '이메일 형식으로 작성해 주세요.',
@@ -21,7 +28,7 @@ const EMAIL_RULES: RegisterOptions = {
 };
 
 const NICKNAME_RULES: RegisterOptions = {
-  required: generateRequiredMessage('닉네임'),
+  required: generateRequiredMessage('nickname'),
   maxLength: {
     value: MAX_NICKNAME_LENGTH,
     message: `닉네임은 최대 ${MAX_NICKNAME_LENGTH}자까지 가능합니다.`,
@@ -43,15 +50,15 @@ const PASSWORD_RULES: RegisterOptions = {
 export const PASSWORD_CONFIRM_RULES = (
   passwordValue: string
 ): RegisterOptions => ({
-  required: generateRequiredMessage('비밀번호 확인'),
+  required: generateRequiredMessage('passwordConfirmation'),
   validate: value => value === passwordValue || '비밀번호가 일치하지 않습니다.',
 });
 
 const VALIDATION_RULES: Record<Field, RegisterOptions> = {
-  이메일: EMAIL_RULES,
-  비밀번호: PASSWORD_RULES,
-  '비밀번호 확인': {},
-  닉네임: NICKNAME_RULES,
+  email: EMAIL_RULES,
+  password: PASSWORD_RULES,
+  passwordConfirmation: {},
+  nickname: NICKNAME_RULES,
 };
 
 export default VALIDATION_RULES;

--- a/src/constants/formValidation.ts
+++ b/src/constants/formValidation.ts
@@ -1,3 +1,4 @@
+import { josa } from 'es-hangul';
 import { RegisterOptions } from 'react-hook-form';
 
 export type Field = 'email' | 'password' | 'passwordConfirmation' | 'nickname';
@@ -16,7 +17,8 @@ const MIN_PASSWORD_LENGTH = 8;
 const generateRequiredMessage = (name: Field): string => {
   if (name === 'passwordConfirmation')
     return `${FIELD_DICTIONARY[name]}을 입력해주세요.`;
-  return `${FIELD_DICTIONARY[name]}은/는 필수 입력입니다.`;
+
+  return `${josa(FIELD_DICTIONARY[name], '은/는')} 필수 입력입니다.`;
 };
 
 const EMAIL_RULES: RegisterOptions = {
@@ -36,7 +38,7 @@ const NICKNAME_RULES: RegisterOptions = {
 };
 
 const PASSWORD_RULES: RegisterOptions = {
-  required: generateRequiredMessage('비밀번호'),
+  required: generateRequiredMessage('password'),
   minLength: {
     value: MIN_PASSWORD_LENGTH,
     message: `비밀번호는 최소 ${MIN_PASSWORD_LENGTH}자 이상입니다.`,

--- a/src/pages/signin/components/SigninForm.tsx
+++ b/src/pages/signin/components/SigninForm.tsx
@@ -1,0 +1,31 @@
+import Form from '@/components/Form';
+
+export default function LoginForm() {
+  return (
+    <div className='mx-auto w-full md:max-w-384 xl:max-w-640'>
+      <Form
+        onSubmit={() => {
+          console.log('로그인 폼 제출');
+        }}
+      >
+        <Form.Label className='mb-10 xl:mb-16'>
+          <Form.Input
+            name='email'
+            placeholder='이메일'
+            required
+            autoComplete='email'
+          />
+        </Form.Label>
+        <Form.Label className='mb-20 xl:mb-24'>
+          <Form.PasswordInput
+            name='password'
+            placeholder='비밀번호'
+            required
+            autoComplete='password'
+          />
+        </Form.Label>
+        <Form.Submit>로그인</Form.Submit>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,0 +1,9 @@
+import SigninForm from '@/pages/signin/components/SigninForm';
+
+export default function LoginPage() {
+  return (
+    <div>
+      <SigninForm />
+    </div>
+  );
+}

--- a/src/pages/signup/components/SignupForm.tsx
+++ b/src/pages/signup/components/SignupForm.tsx
@@ -1,0 +1,52 @@
+import Form from '@/components/Form';
+
+export default function SignupForm() {
+  return (
+    <div className='mx-auto w-full md:max-w-384 xl:max-w-640'>
+      <Form
+        onSubmit={() => {
+          console.log('회원가입 폼 제출');
+        }}
+      >
+        <Form.Label className='mb-20 md:mb-40'>
+          <Form.LabelHeader className='mb-16 md:mb-20'>이메일</Form.LabelHeader>
+          <Form.Input
+            name='email'
+            placeholder='이메일'
+            autoComplete='email'
+            required
+          />
+        </Form.Label>
+        <Form.Label className='mb-10 md:mb-16'>
+          <Form.LabelHeader className='mb-16 md:mb-20'>
+            비밀번호
+          </Form.LabelHeader>
+          <Form.PasswordInput
+            name='password'
+            placeholder='비밀번호'
+            autoComplete='password'
+            required
+          />
+        </Form.Label>
+        <Form.Label className='mb-20 md:mb-40'>
+          <Form.PasswordInput
+            name='passwordConfirmation'
+            placeholder='비밀번호 확인'
+            autoComplete='password'
+            required
+          />
+        </Form.Label>
+        <Form.Label className='mb-30 md:mb-40'>
+          <Form.LabelHeader className='mb-16 md:mb-20'>닉네임</Form.LabelHeader>
+          <Form.Input
+            name='nickname'
+            placeholder='닉네임'
+            autoComplete='nickname'
+            required
+          />
+        </Form.Label>
+        <Form.Submit>가입하기</Form.Submit>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,0 +1,9 @@
+import SignupForm from '@/pages/signup/components/SignupForm';
+
+export default function SignupPage() {
+  return (
+    <div>
+      <SignupForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44 #43 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

공용 컴포넌트 form 으로 signin form, signup form 만들었습니다.
에러 메시지 OO 은/는 구분은 es hangul 의 josa 메서드를 사용했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/dd8dcc54-4857-4a04-8eb8-4d23cb2383a5)

![image](https://github.com/user-attachments/assets/1953692b-7873-439c-8d9e-24290e85dda3)

![image](https://github.com/user-attachments/assets/47490051-6d58-462e-971d-0cb039325c46)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
요구사항에서는 login 페이지고, 저도 loginForm, loginPage 로 작업하고 있었는데,
signin === login 동의어에서 그냥 signin 으로 해볼까 하고 변경했습니다.
근거는
- 헤더에서 분기처리 된 것처럼 HeaderForSign 일관성 유지
- 스웨거에서도 signin 이라고 되어 있네요