### PR TITLE
feat/랜딩페이지 퍼블리싱(pc)

### DIFF
--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -1,7 +1,7 @@
 import Up from '@/assets/icons/ic-down-chevron.svg';
 import Plus from '@/assets/icons/ic-plus.svg';
 import Button from '@/components/Button';
-import Card from '@/shared/Card';
+import EpigramCard from '@/shared/EpigramCard';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -43,13 +43,13 @@ export default function Feed() {
       behavior: 'smooth',
     });
   };
-  const [data, setData] = useState<
+  const [cards, setCards] = useState<
     { content: string; author: string; tags: string[] }[]
   >([]);
 
   useEffect(() => {
     setTimeout(() => {
-      setData(mockDataArray);
+      setCards(mockDataArray);
     }, 500);
   }, []);
 
@@ -60,12 +60,12 @@ export default function Feed() {
           피드
         </h1>
         <div className='grid grid-cols-1 gap-x-8 gap-y-16 md:grid-cols-2 md:gap-x-12 md:gap-y-24 xl:gap-x-30 xl:gap-y-40'>
-          {data.map((item, index) => (
-            <Card
+          {cards.map((card, index) => (
+            <EpigramCard
               key={index}
-              content={item.content}
-              author={item.author}
-              tags={item.tags.map(tag => `#${tag} `)}
+              content={card.content}
+              author={card.author}
+              tags={card.tags.map(tag => `#${tag} `)}
             />
           ))}
         </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,108 @@
+import DownIcon from '@/assets/icons/ic-down-chevron-double.svg';
+import LandingImg01 from '@/assets/images/img-landing-01-lg.png';
+import LandingImg02 from '@/assets/images/img-landing-02-md.png';
+import LandingImg03 from '@/assets/images/img-landing-03-md.png';
+import EpigramLogo from '@/assets/logos/logo-epigram-wordmark-xl.svg';
+import Button from '@/components/Button';
+import Image from 'next/image';
+
 export default function Home() {
   return (
-    <main className='m-4 flex flex-col items-center justify-between p-24'>
-      에피그램
+    <main>
+      <section className='bg-stripe-pattern bg-stripe-size flex h-screen w-full flex-col items-center justify-center'>
+        <div className='flex flex-col items-center'>
+          <h1 className='text-center font-secondary text-40 font-normal'>
+            나만 갖고 있기엔
+            <br />
+            아까운 글이 있지 않나요?
+          </h1>
+          <p className='pb-48 pt-40 text-center font-secondary text-20 font-normal'>
+            다른 사람들과 감정을 공유해 보세요
+          </p>
+          <Button>시작하기</Button>
+        </div>
+        <button className='absolute bottom-0 mx-auto animate-bounce'>
+          <p className='font-primary text-16 font-semibold text-blue-400'>
+            더 알아보기
+          </p>
+          <DownIcon className='mx-auto h-24 w-24 text-blue-400' />
+        </button>
+      </section>
+
+      <div className='bg-zigzag-pattern h-30 w-full'></div>
+      <section className='h-full w-full bg-background-100 font-primary'>
+        <div className='px-24 py-124 md:px-180 xl:px-300 xl:py-240'>
+          <div className='mb-380 flex items-center justify-center gap-x-80'>
+            <Image
+              className='hidden xl:block'
+              src={LandingImg01}
+              alt='랜딩페이지 이미지 01'
+              width={744}
+            />
+            <div className='mt-auto'>
+              <p className='break-keep pb-40 text-32 font-bold'>
+                명언이나 글귀,
+                <br />
+                토막 상식들을 공유해 보세요.
+              </p>
+              <p className='break-keep text-24 text-blue-500'>
+                나만 알던 소중한 글들을
+                <br />
+                다른 사람들에게 전파하세요.
+              </p>
+            </div>
+          </div>
+          <div className='mb-380 flex items-center justify-center gap-x-80'>
+            <div className='mt-auto text-right'>
+              <p className='break-keep pb-40 text-32 font-bold'>
+                감정 상태에 따라,
+                <br />
+                알맞은 위로를 받을 수 있어요.
+              </p>
+              <p className='break-keep text-24 text-blue-500'>
+                태그를 통해 글을 모아 볼 수 있어요.
+              </p>
+            </div>
+            <Image
+              className='hidden xl:block'
+              src={LandingImg02}
+              alt='랜딩페이지 이미지 02'
+              width={744}
+            />
+          </div>
+          <div className='mb-210 flex items-center justify-center gap-x-80'>
+            <Image
+              className='hidden xl:block'
+              src={LandingImg03}
+              alt='랜딩페이지 이미지 03'
+              width={744}
+            />
+            <div className='mt-auto'>
+              <p className='break-keep pb-40 text-32 font-bold'>
+                내가 요즘 어떤 감정 상태인지
+                <br />
+                통계로 한눈에 볼 수 있어요.
+              </p>
+              <p className='break-keep text-24 text-blue-500'>
+                감정 달력으로
+                <br />내 마음에 담긴 감정을 확인해보세요
+              </p>
+            </div>
+          </div>
+          <div></div>
+        </div>
+      </section>
+      <section>
+        <p className='flex flex-col items-center bg-background-100 pb-100 pt-270 text-center font-primary text-32 font-bold'>
+          사용자들이 직접
+          <br />
+          인용한 에피그램들
+        </p>
+      </section>
+      <section className='bg-stripe-pattern bg-stripe-size flex h-[1040px] flex-col items-center justify-center gap-y-48'>
+        <EpigramLogo />
+        <Button>시작하기</Button>
+      </section>
     </main>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import DownIcon from '@/assets/icons/ic-down-chevron-double.svg';
 import LandingImg01 from '@/assets/images/img-landing-01-lg.png';
 import LandingImg02 from '@/assets/images/img-landing-02-md.png';
 import LandingImg03 from '@/assets/images/img-landing-03-md.png';
+import LandingImg04 from '@/assets/images/img-landing-04-lg.png';
 import EpigramLogo from '@/assets/logos/logo-epigram-wordmark-xl.svg';
 import Button from '@/components/Button';
 import Image from 'next/image';
@@ -92,12 +93,18 @@ export default function Home() {
           <div></div>
         </div>
       </section>
-      <section>
-        <p className='flex flex-col items-center bg-background-100 pb-100 pt-270 text-center font-primary text-32 font-bold'>
+      <section className='flex flex-col items-center bg-background-100'>
+        <p className='pb-100 text-center font-primary text-32 font-bold'>
           사용자들이 직접
           <br />
           인용한 에피그램들
         </p>
+        <Image
+          className='pb-60'
+          src={LandingImg04}
+          alt='에피그램 예시'
+          width={640}
+        />
       </section>
       <section className='bg-stripe-pattern bg-stripe-size flex h-[1040px] flex-col items-center justify-center gap-y-48'>
         <EpigramLogo />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,11 +8,20 @@ import Button from '@/components/Button';
 import Image from 'next/image';
 
 export default function Home() {
+  const handlePageScroll = () => {
+    const element = document.getElementById('scrollPoint');
+    if (element) {
+      window.scrollTo({
+        top: element.offsetTop,
+        behavior: 'smooth',
+      });
+    }
+  };
   return (
     <main>
-      <section className='bg-stripe-pattern bg-stripe-size flex h-screen w-full flex-col items-center justify-center'>
+      <section className='bg-stripe-pattern bg-stripe-size flex h-744 w-full flex-col items-center xl:h-screen'>
         <div className='flex flex-col items-center'>
-          <h1 className='text-center font-secondary text-40 font-normal'>
+          <h1 className='pt-200 text-center font-secondary text-40 font-normal xl:pt-300'>
             나만 갖고 있기엔
             <br />
             아까운 글이 있지 않나요?
@@ -22,16 +31,21 @@ export default function Home() {
           </p>
           <Button>시작하기</Button>
         </div>
-        <button className='absolute bottom-0 mx-auto animate-bounce'>
+        <button
+          onClick={handlePageScroll}
+          className='mx-auto mt-auto animate-bounce'
+        >
           <p className='font-primary text-16 font-semibold text-blue-400'>
             더 알아보기
           </p>
           <DownIcon className='mx-auto h-24 w-24 text-blue-400' />
         </button>
       </section>
-
       <div className='bg-zigzag-pattern h-30 w-full'></div>
-      <section className='h-full w-full bg-background-100 font-primary'>
+      <section
+        id='scrollPoint'
+        className='h-full w-full bg-background-100 font-primary'
+      >
         <div className='px-24 py-124 md:px-180 xl:px-300 xl:py-240'>
           <div className='mb-380 flex items-center justify-center gap-x-80'>
             <Image
@@ -106,7 +120,7 @@ export default function Home() {
           width={640}
         />
       </section>
-      <section className='bg-stripe-pattern bg-stripe-size flex h-[1040px] flex-col items-center justify-center gap-y-48'>
+      <section className='bg-stripe-pattern bg-stripe-size flex h-screen flex-col items-center justify-center gap-y-48'>
         <EpigramLogo />
         <Button>시작하기</Button>
       </section>

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -1,12 +1,10 @@
-import { ReactNode } from 'react';
-
 interface CardProps {
   content: string;
   author: string;
   tags: string[];
 }
 
-export default function Card({ content, author, tags }: CardProps) {
+export default function EpigramCard({ content, author, tags }: CardProps) {
   return (
     <div className='font-secondary'>
       <div className='bg-stripe-pattern bg-stripe-size mb-8 flex min-h-295 flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23'>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38

## 📝작업 내용

> ### 랜딩 페이지 pc 퍼블리싱 작업 진행
#### 이후 보완할 작업 사항
* 태블릿, 모바일 반응형 작업 필요
* section 하단에 지그재그 라인 추가
* 시작하기 버튼 onClick 연결

### 폴더 구조 변경
* 📂 fead
* ┣  index.tsx

### 네이밍 변경
* [before]Card.tsx -> [After]EpigramCard.tsx


### 스크린샷 (선택)
![landing01](https://github.com/user-attachments/assets/42d46b78-d5bd-4014-8714-cf4a38927a06)


## 💬리뷰 요구사항(선택)

> Card 컴포넌트 이름이 바뀌어서, 컴포넌트가 사용된 페이지가 있다면 적용이 안될 수 있습니다. 
회의때 언급드리고, 적용된 페이지들은 제가 수정하겠습니다