### PR TITLE
Refactor/에피그램 카드 variant type 추가설정

### DIFF
--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -86,6 +86,7 @@ export default function Feed() {
               content={card.content}
               author={card.author}
               tags={card.tags.map(tag => `#${tag} `)}
+              variant='feed'
             />
           ))}
         </div>

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -17,12 +17,18 @@ export default function EpigramCard({
   variant = 'normal',
 }: CardProps) {
   const EpigramCardStyle = twMerge(
-    'stripe-pattern mb-8 flex flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23',
+    'transition-animation font-secondary',
     styleByVariant[variant]
   );
+
   return (
-    <div className='transition-animation font-secondary'>
-      <div className={EpigramCardStyle}>
+    <div className={EpigramCardStyle}>
+      <div
+        className={clsx(
+          'stripe-pattern mb-8 flex flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23',
+          { 'min-h-140 md:min-h-180 xl:min-h-295': variant === 'feed' }
+        )}
+      >
         <div className='flex-1'>
           <div className='text-14 font-normal leading-24 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
             {content}
@@ -34,13 +40,13 @@ export default function EpigramCard({
       </div>
       {/* TODO: tag 컴포넌트 연결 */}
       <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
-        {tags}
+        {tags.join(', ')}
       </div>
     </div>
   );
 }
 
 const styleByVariant: Record<EpigramVariant, string> = {
-  feed: 'md:w-294 xl:w-585 xl:min-h-295 md:min-h-180 min-h-140',
+  feed: 'md:w-294 xl:w-585',
   normal: 'xl:w-640 md:w-384 w-312',
 };

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -1,19 +1,34 @@
+import clsx from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
 interface CardProps {
   content: string;
   author: string;
   tags: string[];
+  variant?: EpigramVariant;
 }
 
-export default function EpigramCard({ content, author, tags }: CardProps) {
+type EpigramVariant = 'normal' | 'feed';
+
+export default function EpigramCard({
+  content,
+  author,
+  tags,
+  variant = 'normal',
+}: CardProps) {
+  const EpigramCardStyle = twMerge(
+    'stripe-pattern mb-8 flex flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23',
+    styleByVariant[variant]
+  );
   return (
-    <div className='transition-animation font-secondary md:w-294 xl:w-585'>
-      <div className='stripe-pattern mb-8 flex min-h-295 flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23'>
+    <div className='transition-animation font-secondary'>
+      <div className={EpigramCardStyle}>
         <div className='flex-1'>
           <div className='text-14 font-normal leading-24 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
             {content}
           </div>
         </div>
-        <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+        <div className='mt-20 text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
           - {author} -
         </div>
       </div>
@@ -24,3 +39,8 @@ export default function EpigramCard({ content, author, tags }: CardProps) {
     </div>
   );
 }
+
+const styleByVariant: Record<EpigramVariant, string> = {
+  feed: 'md:w-294 xl:w-585 xl:min-h-295 md:min-h-180 min-h-140',
+  normal: 'xl:w-640 md:w-384 w-312',
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #80 

## 📝작업 내용

에피그램 카드를 여러 곳에서 사용할 수 있도록 CSS 리팩토링을 진행했습니다
props로 variant값을 전달하면 variant값에 따라 그에 맞는 width, height가 적용되도록 수정했습니다.
variant type 종류는 ```normal```, ```feed```가 있고, 기본값은 ```normal```입니다. 
필수 값이 아니라서 그냥 에피그램 카드 컴포넌트 사용하시면 ```normal```이 적용됩니다

* 메인페이지, 마이페이지: normal
* 피드페이지: feed

### 스크린샷 (선택)

### 메인페이지, 마이페이지에서의 에피그램카드
```
<Epigram variant='normal' ... /> or <Epigram />
```
![스크린샷 2024-09-25 오후 12 25 27](https://github.com/user-attachments/assets/bd293665-1f4f-4425-91e9-64b1c5774733)

### 피드페이지에서의 에피그램카드
```
<Epigram variant='feed' />
```

![스크린샷 2024-09-25 오후 12 25 48](https://github.com/user-attachments/assets/a82b0e7a-b498-4a14-9bdb-4f90ed6f84f8)


## 💬리뷰 요구사항(선택)
