### PR TITLE
feat/회원가입 기능

### DIFF
--- a/src/constants/apiConstants.ts
+++ b/src/constants/apiConstants.ts
@@ -1,2 +1,12 @@
 export const BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+export const allowedEndpoints = [
+  '/users',
+  '/oauthApps',
+  '/images',
+  '/epigrams',
+  '/emotionLogs',
+  '/comments',
+  '/auth',
+];

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -17,9 +17,4 @@ const signupUser = async (data: SignUpRequestBody) => {
   return response.data;
 };
 
-const refreshToken = async (refreshToken: RefreshToken) => {
-  const response = await instance.post('auth/refresh-token', refreshToken);
-  return response.data;
-};
-
-export { signinUser, signupUser, refreshToken };
+export { signinUser, signupUser };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -10,7 +10,10 @@ const signinUser = async (data: SignInRequestBody) => {
 };
 
 const signupUser = async (data: SignUpRequestBody) => {
-  const response = await instance.post('auth/signUp', data);
+  const response = await axios.post('/api/auth/signUp', data, {
+    headers: { 'Content-Type': 'application/json' },
+    withCredentials: true,
+  });
   return response.data;
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,8 +5,15 @@ import type { NextRequest } from 'next/server';
 export function middleware(req: NextRequest) {
   const cookies = cookie.parse(req.headers.get('cookie') || '');
   const accessToken = cookies.accessToken;
-  if (!accessToken) {
+
+  const { pathname } = req.nextUrl;
+
+  if (!accessToken && !['/signin', '/signup'].includes(pathname)) {
     return NextResponse.redirect(new URL('/signin', req.url));
+  }
+
+  if (accessToken && ['/signin', '/signup'].includes(pathname)) {
+    return NextResponse.redirect(new URL('/', req.url));
   }
 
   return NextResponse.next();
@@ -14,10 +21,11 @@ export function middleware(req: NextRequest) {
 
 export const config = {
   matcher: [
-    // '/addepigram/:path*',
-    // '/feed/:path*',
-    // '/mypage/:path*',
-    // '/main/:path*',
+    '/signin',
+    '/signup',
+    '/feed/:path*',
     '/epigrams/:path*',
+    '/addepigram',
+    '/mypage',
   ],
 };

--- a/src/pages/api/auth/signIn.ts
+++ b/src/pages/api/auth/signIn.ts
@@ -31,8 +31,6 @@ export default async function handler(
       ]);
       res.status(200).json({ message: '로그인에 성공했습니다.', user });
     } catch (error: any) {
-      const errorMessage =
-        error.response?.data?.message || error.message || 'Unknown error';
       const errorStatus = error.response?.status || 500;
       res.status(errorStatus).json(error.response?.data);
     }

--- a/src/pages/api/auth/signUp.ts
+++ b/src/pages/api/auth/signUp.ts
@@ -10,7 +10,7 @@ export default async function handler(
     const data: SignInRequestBody = req.body;
 
     try {
-      const response = await instance.post<SignInResponse>('auth/signUp', data);
+      const response = await instance.post<SignUpResponse>('auth/signUp', data);
 
       const { user, accessToken, refreshToken } = response.data;
       res.setHeader('Set-Cookie', [

--- a/src/pages/api/auth/signUp.ts
+++ b/src/pages/api/auth/signUp.ts
@@ -7,7 +7,7 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method === 'POST') {
-    const data: SignInRequestBody = req.body;
+    const data: SignUpRequestBody = req.body;
 
     try {
       const response = await instance.post<SignUpResponse>('auth/signUp', data);

--- a/src/pages/api/auth/signUp.ts
+++ b/src/pages/api/auth/signUp.ts
@@ -1,0 +1,40 @@
+import instance from '@/api/comments/axios';
+import { serialize } from 'cookie';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'POST') {
+    const data: SignInRequestBody = req.body;
+
+    try {
+      const response = await instance.post<SignInResponse>('auth/signUp', data);
+
+      const { user, accessToken, refreshToken } = response.data;
+      res.setHeader('Set-Cookie', [
+        serialize('accessToken', accessToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV !== 'development',
+          maxAge: 60 * 60,
+          sameSite: 'strict',
+          path: '/',
+        }),
+        serialize('refreshToken', refreshToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV !== 'development',
+          maxAge: 60 * 60 * 24 * 7,
+          sameSite: 'strict',
+          path: '/',
+        }),
+      ]);
+      res.status(200).json({ message: '회원가입에 성공했습니다.', user });
+    } catch (error: any) {
+      const errorStatus = error.response?.status || 500;
+      res.status(errorStatus).json(error.response?.data);
+    }
+  } else {
+    res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/src/pages/api/authProxy.ts
+++ b/src/pages/api/authProxy.ts
@@ -1,4 +1,5 @@
 import instance from '@/api/comments/axios';
+import { allowedEndpoints } from '@/constants/apiConstants';
 import { parse } from 'cookie';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -14,15 +15,6 @@ export default async function handler(
   }
 
   const { endpoint, method = 'GET', data = {} } = req.body;
-  const allowedEndpoints = [
-    '/users',
-    '/oauthApps',
-    '/images',
-    '/epigrams',
-    '/emotionLogs',
-    '/comments',
-    '/auth',
-  ];
 
   if (!allowedEndpoints.some(allowed => endpoint.startsWith(allowed))) {
     return res.status(403).json({ message: 'Forbidden endpoint' });

--- a/src/pages/api/authProxy.ts
+++ b/src/pages/api/authProxy.ts
@@ -28,7 +28,6 @@ export default async function handler(
         }),
       ]);
     } catch (error) {
-      console.error(error);
       return res
         .status(401)
         .json({ message: '토큰이 만료되었습니다. 다시 로그인해주세요.' });

--- a/src/pages/signup/components/SignupForm.tsx
+++ b/src/pages/signup/components/SignupForm.tsx
@@ -1,12 +1,31 @@
 import Form from '@/components/Form';
+import { signupUser } from '@/lib/api/auth';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { useMutation } from 'react-query';
 
 export default function SignupForm() {
   const methods = useForm();
+  const router = useRouter();
+  const { setError } = methods;
+  const mutation = useMutation(signupUser, {
+    onSuccess: data => {
+      router.push('/signin');
+    },
+    onError: (error: any) => {
+      if (error.response.status === 500) {
+        setError('nickname', { message: '이미 존재하는 닉네임입니다.' });
+      }
+      const errorMessage = error.response.data.message;
+      const errorDetail = Object.keys(error.response.data.details)[0];
+      setError(errorDetail, { message: errorMessage });
+    },
+  });
   return (
     <Form
-      onSubmit={() => {
-        console.log('회원가입 폼 제출');
+      onSubmit={(data: SignUpRequestBody) => {
+        console.log(data);
+        mutation.mutate(data);
       }}
       methods={methods}
     >

--- a/src/pages/signup/components/SignupForm.tsx
+++ b/src/pages/signup/components/SignupForm.tsx
@@ -10,7 +10,7 @@ export default function SignupForm() {
   const { setError } = methods;
   const mutation = useMutation(signupUser, {
     onSuccess: data => {
-      router.push('/signin');
+      router.push('/');
     },
     onError: (error: any) => {
       if (error.response.status === 500) {
@@ -24,7 +24,6 @@ export default function SignupForm() {
   return (
     <Form
       onSubmit={(data: SignUpRequestBody) => {
-        console.log(data);
         mutation.mutate(data);
       }}
       methods={methods}

--- a/src/types/Auth.types.d.ts
+++ b/src/types/Auth.types.d.ts
@@ -8,6 +8,8 @@ interface UserWithEmail extends User {
 }
 
 interface SignUpResponse {
+  refreshToken: RefreshToken;
+  accessToken: AccessToken;
   user: UserWithEmail;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #65

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원가입 기능도 추가했습니다.
- 닉네임 중복의 경우 에러 status 가 500 으로 분류되는 점을 이용해 분기처리했습니다.
- 로그인 때와 마찬가지로 핸들러 함수를 통해 토큰을 관리했습니다.
- 회원가입 성공시 / 로 리다이렉트
- 토큰이 있을 때 로그인 회원가입 페이지로 이동하지 못하게 미들웨어 설정
- 액세스 토큰은 없고 리프레시 토큰만 있을 때, 토큰 갱신

### 스크린샷 (선택)
<img width="681" alt="image" src="https://github.com/user-attachments/assets/91b645d0-6169-48b5-855f-8250eaba8d11">
<img width="698" alt="image" src="https://github.com/user-attachments/assets/a5cdf31b-f561-4804-ac67-981d05cfefcf">
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/c40840fe-f061-456c-a929-19b31c92e557">

https://github.com/user-attachments/assets/6cfdebd6-c724-40c1-807d-079b690c7b3b


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 이메일 중복 체크
- 회원가입 시 이미지 등록 추가