### PR TITLE
feat/Feed페이지 api연결&스켈레톤 구현

### DIFF
--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -42,7 +42,7 @@ const fetchEpigramCards = async ({ limit }: BasicQuery) => {
 };
 
 export default function Feed() {
-  const [cards, setCards] = useState<EpigramBaseBody[]>([]);
+  const [cards, setCards] = useState<EpigramListType[]>([]);
   const [loading, setLoading] = useState(true); // Loading state
   const [visibleCount, setVisibleCount] = useState(6);
   const [isSingleColumn, setIsSingleColumn] = useState(true);

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -128,7 +128,7 @@ export default function Feed() {
       </div>
 
       {visibleCount < cards.length && (
-        <div className='pt:56 flex items-center justify-center pb-114 xl:pt-80'>
+        <div className='flex items-center justify-center pb-114 pt-56 xl:pt-80'>
           <Button variant='round' color='white' onClick={handleLoadMore}>
             <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
             에피그램 더보기

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -1,12 +1,12 @@
 import SortDouble from '@/assets/icons/ic-dashboard.svg';
-import Up from '@/assets/icons/ic-down-chevron.svg';
 import Plus from '@/assets/icons/ic-plus.svg';
 import SortSingle from '@/assets/icons/ic-sort.svg';
 import Button from '@/components/Button';
 import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
 import EpigramCard from '@/shared/EpigramCard';
+import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
+import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import clsx from 'clsx';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -19,29 +19,32 @@ interface Epigram {
 
 interface BasicQuery {
   limit?: number;
-  cursor?: number;
 }
 
-const fetchEpigramCards = async ({ limit = 3, cursor = 0 }: BasicQuery) => {
+// 에피그램 카드 불러오기
+const fetchEpigramCards = async ({ limit }: BasicQuery) => {
   try {
     const data = await apiRequestWithAtuh({
-      endpoint: `/epigrams?limit=${limit}&cursor=${cursor}`,
+      endpoint: `/epigrams?limit=${limit}`,
       method: 'GET',
     });
-    console.log('응답 데이터:', data);
+    // console.log('응답 데이터:', data);
 
-    return data.list.map((item: any) => ({
-      id: item.id,
-      content: item.content,
-      author: item.author,
-      // tags 배열의 name 값을 추출해서 표시
-      tags: Array.isArray(item.tags)
-        ? item.tags.map((tag: any) => tag.name)
-        : [], // tags가 배열일 때만 처리, 아닐 경우 빈 배열
-    }));
+    return {
+      list: data.list.map((epigramCard: any) => ({
+        id: epigramCard.id,
+        content: epigramCard.content,
+        author: epigramCard.author,
+        // tags 배열의 name 값을 추출해서 표시
+        tags: Array.isArray(epigramCard.tags)
+          ? epigramCard.tags.map((tag: any) => tag.name)
+          : [],
+      })),
+      totalCount: data.totalCount,
+    };
   } catch (error) {
     console.error('에피그램 가져오기 실패:', error);
-    return [];
+    return { list: [], totalCount: 0 };
   }
 };
 
@@ -51,36 +54,30 @@ export default function Feed() {
   const [isSingleColumn, setIsSingleColumn] = useState(true);
   const [cursor, setCursor] = useState(0);
 
-  const router = useRouter();
-
-  const handleAddEpigramButtonClick = () => {
-    if (router.pathname === '/addepigram') return;
-    router.push('/addepigram');
-  };
-
-  const handlePageUp = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
-
   useEffect(() => {
     const loadEpigrams = async () => {
-      const epigramData = await fetchEpigramCards({
+      // totalCount 불러오기
+      const { list: initialEpigrams, totalCount } = await fetchEpigramCards({
         limit: 10,
-        cursor,
       });
-      setCards(epigramData);
+
+      // totalCount 값을 limit으로 설정해서 다시 데이터 불러오기
+      const { list: fullEpigrams } = await fetchEpigramCards({
+        limit: totalCount,
+      });
+
+      setCards(fullEpigrams);
     };
     loadEpigrams();
   }, []);
 
+  //에피그램 더보기
   const handleLoadMore = () => {
     setVisibleCount(prevCount => prevCount + 4);
     setCursor(cards.length > 0 ? cards[cards.length - 1].id : 0); // 마지막 아이템의 id를 커서로 설정
   };
 
+  //그리드 레이아웃 변경 토글
   const toggleGridLayout = () => {
     setIsSingleColumn(prevLayout => !prevLayout);
   };
@@ -109,7 +106,6 @@ export default function Feed() {
             </button>
           </div>
         </div>
-
         <div
           className={twMerge(
             'grid gap-x-8 gap-y-16 md:gap-x-12 md:gap-y-24 xl:gap-x-30 xl:gap-y-40',
@@ -141,18 +137,8 @@ export default function Feed() {
       )}
       <div className='fixed bottom-104 right-24 md:bottom-92 md:right-72 xl:bottom-80 xl:right-120'>
         <div className='grid justify-items-end'>
-          <Button
-            variant='round'
-            onClick={handleAddEpigramButtonClick}
-            color='blue'
-            className='mb-8'
-          >
-            <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
-            에피그램 만들기
-          </Button>
-          <Button onClick={handlePageUp} color='blue' variant='round'>
-            <Up className='h-24 w-24 rotate-180' />
-          </Button>
+          <AddEpigramButton />
+          <PageUpButton />
         </div>
       </div>
     </div>

--- a/src/pages/feed/skeletonCard.tsx
+++ b/src/pages/feed/skeletonCard.tsx
@@ -1,0 +1,12 @@
+export default function SkeletonCard() {
+  return (
+    <div className='flex-center bg-background-100'>
+      <div className='animate-pulse'>
+        <div className='h-180 w-294 rounded-2xl bg-zinc-200 xl:h-259 xl:w-585'></div>
+        <div className='flex gap-x-5'>
+          <div className='ml-auto mt-8 h-26 w-97 rounded-xl bg-zinc-200 xl:h-40 xl:w-146'></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/RightFixedButton/AddEpigramButton.tsx
+++ b/src/shared/RightFixedButton/AddEpigramButton.tsx
@@ -1,0 +1,24 @@
+import Plus from '@/assets/icons/ic-plus.svg';
+import Button from '@/components/Button';
+import { useRouter } from 'next/router';
+
+export default function AddEpigramButton() {
+  const router = useRouter();
+
+  const handleAddEpigramButtonClick = () => {
+    if (router.pathname === '/addepigram') return;
+    router.push('/addepigram');
+  };
+
+  return (
+    <Button
+      variant='round'
+      onClick={handleAddEpigramButtonClick}
+      color='blue'
+      className='mb-8'
+    >
+      <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
+      에피그램 만들기
+    </Button>
+  );
+}

--- a/src/shared/RightFixedButton/PageUpButton.tsx
+++ b/src/shared/RightFixedButton/PageUpButton.tsx
@@ -1,0 +1,17 @@
+import Up from '@/assets/icons/ic-down-chevron.svg';
+import Button from '@/components/Button';
+
+const handlePageUp = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};
+
+export default function PageUpButton() {
+  return (
+    <Button onClick={handlePageUp} color='blue' variant='round'>
+      <Up className='h-24 w-24 rotate-180' />
+    </Button>
+  );
+}

--- a/src/types/Epigram.types.d.ts
+++ b/src/types/Epigram.types.d.ts
@@ -15,6 +15,7 @@ interface EpigramBaseBody {
   referenceTitle?: EpigramReferenceTitle;
   referenceUrl?: UrlType;
   tags: EpigramTagName[];
+  id: number;
 }
 
 interface EpigramListType {

--- a/src/types/Epigram.types.d.ts
+++ b/src/types/Epigram.types.d.ts
@@ -15,7 +15,6 @@ interface EpigramBaseBody {
   referenceTitle?: EpigramReferenceTitle;
   referenceUrl?: UrlType;
   tags: EpigramTagName[];
-  id: number;
 }
 
 interface EpigramListType {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용

* Feed페이지의 에피그램 카드 api연결 완료
* 로딩시 스켈레톤 구현
* 오른쪽 하단의 <에피그램 만들기>버튼과 상단으로 이동하는 버튼을 따로 컴포넌트화 시켰습니다

### 📸 스크린샷 

![skeletonFeed](https://github.com/user-attachments/assets/59ee8131-6ffd-4dee-9528-f75fc41e24e1)

## 💬리뷰 요구사항(선택)