### PR TITLE
Feat/에피그램 카드 클릭 시 상세페이지로 이동

### DIFF
--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -120,6 +120,7 @@ export default function Epigrams() {
           {todayEpigram && (
             <div className='mb-16'>
               <EpigramCard
+                id={todayEpigram.id}
                 key={todayEpigram.id}
                 content={todayEpigram.content}
                 author={todayEpigram.author}
@@ -144,6 +145,7 @@ export default function Epigrams() {
           {cards.slice(0, visibleCount).map(card => (
             <div className='mb-16' key={card.id}>
               <EpigramCard
+                id={card.id}
                 content={card.content}
                 author={card.author}
                 tags={card.tags.map(tag => `#${tag} `)}

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -131,9 +131,13 @@ export default function Epigrams() {
           )}
         </div>
         <div className='mt-56 xl:mt-140'>
-          <h1 className='mb-24 font-primary text-16 font-semibold xl:mb-40 xl:text-24'>
-            오늘의 감정은 어떤가요?
-          </h1>
+          <div className='flex justify-between'>
+            <h1 className='mb-24 font-primary text-16 font-semibold xl:mb-40 xl:text-24'>
+              오늘의 감정은 어떤가요?
+            </h1>
+            <button className='h-full w-100 bg-black-100'>감정 저장하기</button>
+          </div>
+
           <div className='flex-center'>
             <EmotionList />
           </div>

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -124,7 +124,7 @@ export default function Feed() {
       </div>
 
       {!loading && visibleCount < cards.length && (
-        <div className='pt:56 flex items-center justify-center pb-114 xl:pt-80'>
+        <div className='flex items-center justify-center pb-114 pt-56 xl:pt-80'>
           <Button variant='round' color='white' onClick={handleLoadMore}>
             <Plus className='mr-8 h-24 w-24' viewBox='0 1 24 24' />
             에피그램 더보기

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -113,6 +113,7 @@ export default function Feed() {
                 .map((card, index) => (
                   <EpigramCard
                     key={index}
+                    id={card.id}
                     content={card.content}
                     author={card.author}
                     tags={card.tags.map(tag => `#${tag} `)}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,16 +19,10 @@ import useModalStore from '@/lib/store/useModalStore';
 import DeleteAlertModalContent from '@/shared/Modal/DeleteAlertModalContent';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 export default function Home() {
   const { openModal } = useModalStore();
-  const router = useRouter();
-
-  const handleStartClick = () => {
-    // 로그인 여부는 미들웨어에서 처리
-    router.push('/epigrams');
-  };
 
   const handlePageScroll = () => {
     const element = document.getElementById('scrollPoint');
@@ -52,7 +46,9 @@ export default function Home() {
           <p className='pb-24 pt-8 text-center font-secondary text-14 font-normal md:pb-32 md:pt-24 md:text-20 xl:pb-48 xl:pt-40'>
             다른 사람들과 감정을 공유해 보세요
           </p>
-          <Button onClick={handleStartClick}>시작하기</Button>
+          <Link href={'/epigrams'}>
+            <Button>시작하기</Button>
+          </Link>
           <Button
             onClick={() => {
               // signoutUser();
@@ -252,7 +248,9 @@ export default function Home() {
         <div className='transition-animation flex-center h-600 flex-col gap-y-48 md:h-528 xl:h-screen'>
           <LogoLg className='hidden xl:block' />
           <LogoMd className='block xl:hidden' />
-          <Button onClick={handleStartClick}>시작하기</Button>
+          <Link href={'/epigrams'}>
+            <Button>시작하기</Button>
+          </Link>
         </div>
       </section>
     </main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,7 +46,7 @@ export default function Home() {
           <p className='pb-24 pt-8 text-center font-secondary text-14 font-normal md:pb-32 md:pt-24 md:text-20 xl:pb-48 xl:pt-40'>
             다른 사람들과 감정을 공유해 보세요
           </p>
-          <Link href={'/epigrams'}>
+          <Link href={'/epigrams'} passHref>
             <Button>시작하기</Button>
           </Link>
           <Button

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
 interface Epigram {
+  id: number;
   content: string;
   author: string;
   tags: { id: number; name: string }[]; // tags 배열에 객체가 포함된 경우
@@ -113,6 +114,7 @@ const Search: React.FC = () => {
       <div>
         {searchResult.map((epigram, index) => (
           <EpigramCard
+            id={epigram.id}
             key={index}
             content={epigram.content}
             author={epigram.author}

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
+import Link from 'next/link';
 import { twMerge } from 'tailwind-merge';
 
 interface CardProps {
+  id: number;
   content: string;
   author: string;
   tags: string[];
@@ -11,6 +13,7 @@ interface CardProps {
 type EpigramVariant = 'normal' | 'feed';
 
 export default function EpigramCard({
+  id,
   content,
   author,
   tags,
@@ -22,27 +25,29 @@ export default function EpigramCard({
   );
 
   return (
-    <div className={EpigramCardStyle}>
-      <div
-        className={clsx(
-          'stripe-pattern mb-8 flex flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23',
-          { 'min-h-140 md:min-h-180 xl:min-h-295': variant === 'feed' }
-        )}
-      >
-        <div className='flex-1'>
-          <div className='text-14 font-normal leading-24 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
-            {content}
+    <Link href={`/epigrams/${id}`} passHref>
+      <div className={EpigramCardStyle}>
+        <div
+          className={clsx(
+            'stripe-pattern mb-8 flex flex-col justify-between rounded-2xl bg-blue-100 px-24 py-23',
+            { 'min-h-140 md:min-h-180 xl:min-h-295': variant === 'feed' }
+          )}
+        >
+          <div className='flex-1'>
+            <div className='text-14 font-normal leading-24 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+              {content}
+            </div>
+          </div>
+          <div className='mt-20 text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+            - {author} -
           </div>
         </div>
-        <div className='mt-20 text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
-          - {author} -
+        {/* TODO: tag 컴포넌트 연결 */}
+        <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
+          {tags.join(', ')}
         </div>
       </div>
-      {/* TODO: tag 컴포넌트 연결 */}
-      <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
-        {tags.join(', ')}
-      </div>
-    </div>
+    </Link>
   );
 }
 

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -17,7 +17,7 @@ export default function EpigramCard({
   variant = 'normal',
 }: CardProps) {
   const EpigramCardStyle = twMerge(
-    'transition-animation font-secondary',
+    'transition-animation cursor-pointer font-secondary duration-100 hover:scale-105',
     styleByVariant[variant]
   );
 

--- a/src/shared/EpigramCard.tsx
+++ b/src/shared/EpigramCard.tsx
@@ -44,7 +44,7 @@ export default function EpigramCard({
         </div>
         {/* TODO: tag 컴포넌트 연결 */}
         <div className='text-right text-14 font-normal leading-24 text-blue-400 md:text-16 md:leading-26 xl:text-24 xl:leading-40'>
-          {tags.join(', ')}
+          {tags.join('  ')}
         </div>
       </div>
     </Link>

--- a/src/shared/Headers/Header.tsx
+++ b/src/shared/Headers/Header.tsx
@@ -5,7 +5,7 @@ import HeaderForLanding from './components/HeaderForLanding';
 import HeaderForSign from './components/HeaderForSign';
 
 const headerByPage: Record<string, JSX.Element> = {
-  '/': <HeaderForLanding />,
+  '/epigrams': <HeaderForLanding />,
   '/signin': <HeaderForSign />,
   '/signup': <HeaderForSign />,
   etc: <HeaderForCommon />,
@@ -17,7 +17,7 @@ export default function Header() {
   const selectedHeader = headerByPage[pathname] || headerByPage.etc;
 
   return (
-    <header className='fixed inset-0 flex justify-between items-center w-full h-52 md:h-60 xl:h-80 px-24 md:px-72 xl:px-120 bg-white border-1 border-solid border-gray-100'>
+    <header className='fixed inset-0 flex h-52 w-full items-center justify-between border-1 border-solid border-gray-100 bg-white px-24 md:h-60 md:px-72 xl:h-80 xl:px-120'>
       {selectedHeader}
     </header>
   );

--- a/src/shared/Headers/components/HeaderForSign.tsx
+++ b/src/shared/Headers/components/HeaderForSign.tsx
@@ -7,7 +7,7 @@ import LogoForHeader from './LogoForHeader';
 export default function HeaderForSign() {
   const router = useRouter();
   const handleLogoClick = () => {
-    router.push('/');
+    router.push('/epigrams');
   };
 
   return (

--- a/src/shared/Headers/components/UserInfo.tsx
+++ b/src/shared/Headers/components/UserInfo.tsx
@@ -10,7 +10,7 @@ interface UserInfoProps {
 export default function UserInfo({ image, nickname, onClick }: UserInfoProps) {
   return (
     <div
-      className='flex justify-between items-center gap-6 cursor-pointer'
+      className='flex cursor-pointer items-center justify-between gap-6'
       onClick={onClick}
     >
       {image ? (
@@ -19,9 +19,9 @@ export default function UserInfo({ image, nickname, onClick }: UserInfoProps) {
           styles='w-24 h-24 border-1 border-solid border-gray-200 rounded-full'
         />
       ) : (
-        <IconUserSigned className='w-16 xl:w-24 h-16 xl:h-24' />
+        <IconUserSigned className='h-16 w-16 xl:h-24 xl:w-24' />
       )}
-      <p className='font-primary text-gray-300 text-13 xl:text-14 font-semibold leading-22 xl:leading-24 cursor-pointer'>
+      <p className='cursor-pointer font-primary text-13 font-semibold leading-22 text-gray-300 xl:text-14 xl:leading-24'>
         {nickname}
       </p>
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 에피그램 카드 클릭 시 'epigrams/[id]'로 이동합니다
* 에피그램 카드 하단의 태그들 사이에 쉼표(,) 가 붙어있었는데 삭제했습니다
* 랜딩 페이지에서 <시작하기> 버튼을 router 이동으로 구현했었는데, link로 변경했습니다 (예전 pr에서 윤호님 코드리뷰를 지금 확인했네요😓)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
