### PR TITLE
Feat/메인페이지 '오늘의 감정' Select 

### DIFF
--- a/src/lib/api/getEpigramCard.ts
+++ b/src/lib/api/getEpigramCard.ts
@@ -32,4 +32,31 @@ const fetchEpigramCards = async () => {
   }
 };
 
-export { fetchEpigramCards };
+// 오늘의 에피그램 불러오기
+const fetchTodayEpigram = async () => {
+  try {
+    const data = await apiRequestWithAtuh({
+      endpoint: `/epigrams/today`,
+      method: 'GET',
+    });
+
+    return {
+      id: data.id,
+      content: data.content,
+      author: data.author,
+      tags: Array.isArray(data.tags)
+        ? data.tags.map((tag: any) => tag.name)
+        : [],
+      // 기본값 설정
+      likeCount: data.likeCount ?? 0,
+      writerId: data.writerId ?? null,
+      referenceUrl: data.referenceUrl ?? '',
+      referenceTitle: data.referenceTitle ?? '',
+    };
+  } catch (error) {
+    console.error('오늘의 에피그램 가져오기 실패:', error);
+    return null;
+  }
+};
+
+export { fetchEpigramCards, fetchTodayEpigram };

--- a/src/lib/api/getEpigramCard.ts
+++ b/src/lib/api/getEpigramCard.ts
@@ -1,0 +1,30 @@
+import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
+
+interface BasicQuery {
+  limit?: number;
+}
+
+// 에피그램 카드 불러오기
+const fetchEpigramCards = async ({ limit }: BasicQuery) => {
+  try {
+    const { list, totalCount } = await apiRequestWithAtuh({
+      endpoint: `/epigrams?limit=${limit}`,
+      method: 'GET',
+    });
+
+    return {
+      list: list.map(({ id, content, author, tags }: any) => ({
+        id,
+        content,
+        author,
+        tags: Array.isArray(tags) ? tags.map(({ name }: any) => name) : [],
+      })),
+      totalCount,
+    };
+  } catch (error) {
+    console.error('에피그램 가져오기 실패:', error);
+    return { list: [], totalCount: 0 };
+  }
+};
+
+export { fetchEpigramCards };

--- a/src/lib/api/getEpigramCard.ts
+++ b/src/lib/api/getEpigramCard.ts
@@ -1,19 +1,24 @@
 import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
 
-interface BasicQuery {
-  limit?: number;
-}
-
 // 에피그램 카드 불러오기
-const fetchEpigramCards = async ({ limit }: BasicQuery) => {
+const fetchEpigramCards = async () => {
   try {
-    const { list, totalCount } = await apiRequestWithAtuh({
-      endpoint: `/epigrams?limit=${limit}`,
+    // 첫 번째 요청: 기본 limit으로 요청하여 totalCount 가져오기
+    const initialResponse = await apiRequestWithAtuh({
+      endpoint: `/epigrams?limit=10`,
+      method: 'GET',
+    });
+
+    const { totalCount } = initialResponse;
+
+    // 두 번째 요청: totalCount로 다시 요청하여 전체 데이터를 가져오기
+    const finalResponse = await apiRequestWithAtuh({
+      endpoint: `/epigrams?limit=${totalCount}`,
       method: 'GET',
     });
 
     return {
-      list: list.map(({ id, content, author, tags }: any) => ({
+      list: finalResponse.list.map(({ id, content, author, tags }: any) => ({
         id,
         content,
         author,
@@ -22,7 +27,7 @@ const fetchEpigramCards = async ({ limit }: BasicQuery) => {
       totalCount,
     };
   } catch (error) {
-    console.error('에피그램 가져오기 실패:', error);
+    console.error('에피그램 카드 가져오기 실패:', error);
     return { list: [], totalCount: 0 };
   }
 };

--- a/src/lib/api/getEpigramCard.ts
+++ b/src/lib/api/getEpigramCard.ts
@@ -40,18 +40,26 @@ const fetchTodayEpigram = async () => {
       method: 'GET',
     });
 
+    const {
+      id,
+      content,
+      author,
+      tags,
+      likeCount = 0,
+      writerId = null,
+      referenceUrl = '',
+      referenceTitle = '',
+    } = data;
+
     return {
-      id: data.id,
-      content: data.content,
-      author: data.author,
-      tags: Array.isArray(data.tags)
-        ? data.tags.map((tag: any) => tag.name)
-        : [],
-      // 기본값 설정
-      likeCount: data.likeCount ?? 0,
-      writerId: data.writerId ?? null,
-      referenceUrl: data.referenceUrl ?? '',
-      referenceTitle: data.referenceTitle ?? '',
+      id,
+      content,
+      author,
+      tags: Array.isArray(tags) ? tags.map((tag: any) => tag.name) : [],
+      likeCount,
+      writerId,
+      referenceUrl,
+      referenceTitle,
     };
   } catch (error) {
     console.error('오늘의 에피그램 가져오기 실패:', error);

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -10,7 +10,8 @@ import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import { useEffect, useState } from 'react';
 
-import MainPageEmotionList from './MainPageEmotionList';
+import MainPageEmotionList from './mainPageEmotionList';
+import MainPageEmotionCard from './mainPageEmotionList/components/MainPageEmotionCard';
 import { SkeletonCard } from './skeleton';
 
 export default function Epigrams() {
@@ -127,7 +128,7 @@ export default function Epigrams() {
           </div>
           {isEmotionSaved ? (
             <div className='mt-4 flex items-center'>
-              <EmotionCard
+              <MainPageEmotionCard
                 emotionType={selectedEmotion}
                 isSelected={true}
                 handleCardClick={() => {}}

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -111,7 +111,7 @@ export default function Epigrams() {
             <h1 className='mb-24 font-primary text-16 font-semibold xl:mb-40 xl:text-24'>
               오늘의 감정은 어떤가요?
             </h1>
-            <div className='flex items-center'>
+            <div className='flex items-center gap-x-8 xl:mb-40'>
               <button
                 className='h-fit w-fit cursor-pointer rounded-md bg-illust-yellow p-8 font-primary font-semibold duration-100 hover:scale-105'
                 onClick={handleSaveEmotion}
@@ -119,7 +119,7 @@ export default function Epigrams() {
                 감정 저장하기
               </button>
               <button
-                className='bg-illust-gray ml-4 h-full w-fit cursor-pointer rounded-md p-8 font-primary font-semibold duration-100 hover:scale-105'
+                className='bg-illust-gray h-full w-fit cursor-pointer rounded-md p-8 font-primary font-semibold duration-100 hover:scale-105'
                 onClick={handleChooseAgain} // 다시 고르기 버튼 클릭 핸들러
               >
                 다시 고르기

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -1,74 +1,13 @@
 import { useComments } from '@/api/comments/useComments';
 import Plus from '@/assets/icons/ic-plus.svg';
 import Button from '@/components/Button';
-import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
+import { fetchEpigramCards, fetchTodayEpigram } from '@/lib/api/getEpigramCard';
 import Comment from '@/shared/Comment/Comment';
 import EmotionList from '@/shared/EmotionList';
 import EpigramCard from '@/shared/EpigramCard';
 import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import { useEffect, useState } from 'react';
-
-interface BasicQuery {
-  limit?: number;
-}
-
-// 오늘의 에피그램 불러오기
-const fetchTodayEpigram = async () => {
-  try {
-    const data = await apiRequestWithAtuh({
-      endpoint: `/epigrams/today`,
-      method: 'GET',
-    });
-
-    return {
-      id: data.id,
-      content: data.content,
-      author: data.author,
-      tags: Array.isArray(data.tags)
-        ? data.tags.map((tag: any) => tag.name)
-        : [],
-      // 기본값 설정
-      likeCount: data.likeCount ?? 0,
-      writerId: data.writerId ?? null,
-      referenceUrl: data.referenceUrl ?? '',
-      referenceTitle: data.referenceTitle ?? '',
-    };
-  } catch (error) {
-    console.error('오늘의 에피그램 가져오기 실패:', error);
-    return null;
-  }
-};
-
-// 에피그램 카드 불러오기
-const fetchEpigramCards = async ({ limit }: BasicQuery) => {
-  try {
-    const data = await apiRequestWithAtuh({
-      endpoint: `/epigrams?limit=${limit}`,
-      method: 'GET',
-    });
-
-    return {
-      list: data.list.map((epigramCard: any) => ({
-        id: epigramCard.id,
-        content: epigramCard.content,
-        author: epigramCard.author,
-        tags: Array.isArray(epigramCard.tags)
-          ? epigramCard.tags.map((tag: any) => tag.name)
-          : [],
-        //기본값 설정
-        likeCount: epigramCard.likeCount ?? 0,
-        writerId: epigramCard.writerId ?? null,
-        referenceUrl: epigramCard.referenceUrl ?? '',
-        referenceTitle: epigramCard.referenceTitle ?? '',
-      })),
-      totalCount: data.totalCount,
-    };
-  } catch (error) {
-    console.error('에피그램 가져오기 실패:', error);
-    return { list: [], totalCount: 0 };
-  }
-};
 
 export default function Epigrams() {
   const [cards, setCards] = useState<EpigramListType[]>([]);
@@ -92,13 +31,7 @@ export default function Epigrams() {
       setTodayEpigram(fetchedTodayEpigram);
 
       // 최신 에피그램
-      const { list: initialEpigrams, totalCount } = await fetchEpigramCards({
-        limit: 10,
-      });
-      const { list: fullEpigrams } = await fetchEpigramCards({
-        limit: totalCount,
-      });
-
+      const { list: fullEpigrams } = await fetchEpigramCards();
       setCards(fullEpigrams);
     };
 

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -128,17 +128,24 @@ export default function Epigrams() {
           </div>
           {isEmotionSaved ? (
             selectedEmotion && (
-              <div className='flex-center mt-4'>
+              <div className='ml-15 mt-10 flex w-640'>
                 <MainPageEmotionCard
                   emotionType={selectedEmotion}
                   isSelected={true}
                   handleCardClick={() => {}}
                 />
-                {selectedEmotion === 'MOVED' && '감동적인 하루였군요!'}
-                {selectedEmotion === 'HAPPY' && '행복한 하루였군요!'}
-                {selectedEmotion === 'WORRIED' && '걱정이 많았던 하루였군요!'}
-                {selectedEmotion === 'SAD' && '슬픈 하루였군요!'}
-                {selectedEmotion === 'ANGRY' && '분노에 가득찬 하루였군요!'}
+                <p className='flex justify-items-center whitespace-pre-wrap pl-20 font-secondary text-20'>
+                  {selectedEmotion === 'MOVED' &&
+                    `감동이 가득한 하루였군요!\n작은 순간 하나하나가 당신에게 깊은 울림이 되었길 바랍니다.\n앞으로도 많은 감동이 함께하길 응원할게요! `}
+                  {selectedEmotion === 'HAPPY' &&
+                    '오늘 하루가 행복으로 가득했군요!\n그 행복이 오래도록 당신을 따뜻하게 감싸주길 바랍니다. 앞으로도 작은 순간들이 큰 기쁨이 되길 응원해요!'}
+                  {selectedEmotion === 'WORRIED' &&
+                    '많은 고민이 있었던 하루였네요.\n고민 속에서도 한 걸음씩 나아가는 당신을 응원합니다.\n힘든 순간은 지나가고, 더 나은 길이 열릴 거예요'}
+                  {selectedEmotion === 'SAD' &&
+                    '오늘 하루가 슬픔으로 가득했군요.\n당신의 마음이 조금이라도 위로받길 바랍니다. 시간이 지나면\n이 슬픔도 당신에게 의미 있는 기억으로 남길 바라요'}
+                  {selectedEmotion === 'ANGRY' &&
+                    '분노로 가득했던 하루였군요. \n오늘의 분노가 내일의 평온함으로 바뀌길 바라며, 당신의 마음이 조금이라도 가벼워지길 바랍니다.'}
+                </p>
               </div>
             )
           ) : (

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -10,9 +10,9 @@ import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import { useEffect, useState } from 'react';
 
+import SkeletonCard from '../feed/skeletonCard';
 import MainPageEmotionList from './mainPageEmotionList';
 import MainPageEmotionCard from './mainPageEmotionList/components/MainPageEmotionCard';
-import { SkeletonCard } from './skeleton';
 
 export default function Epigrams() {
   const [cards, setCards] = useState<EpigramListType[]>([]);

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -113,7 +113,7 @@ export default function Epigrams() {
             </h1>
             <div className='flex items-center'>
               <button
-                className='h-full w-fit cursor-pointer rounded-md bg-illust-yellow p-8 font-primary font-semibold duration-100 hover:scale-105'
+                className='h-fit w-fit cursor-pointer rounded-md bg-illust-yellow p-8 font-primary font-semibold duration-100 hover:scale-105'
                 onClick={handleSaveEmotion}
               >
                 감정 저장하기
@@ -127,14 +127,20 @@ export default function Epigrams() {
             </div>
           </div>
           {isEmotionSaved ? (
-            <div className='mt-4 flex items-center'>
-              <MainPageEmotionCard
-                emotionType={selectedEmotion}
-                isSelected={true}
-                handleCardClick={() => {}}
-              />
-              <p className='ml-4 text-xl'>{selectedEmotion}한 하루였군요</p>
-            </div>
+            selectedEmotion && (
+              <div className='flex-center mt-4'>
+                <MainPageEmotionCard
+                  emotionType={selectedEmotion}
+                  isSelected={true}
+                  handleCardClick={() => {}}
+                />
+                {selectedEmotion === 'MOVED' && '감동적인 하루였군요!'}
+                {selectedEmotion === 'HAPPY' && '행복한 하루였군요!'}
+                {selectedEmotion === 'WORRIED' && '걱정이 많았던 하루였군요!'}
+                {selectedEmotion === 'SAD' && '슬픈 하루였군요!'}
+                {selectedEmotion === 'ANGRY' && '분노에 가득찬 하루였군요!'}
+              </div>
+            )
           ) : (
             <div className='flex-center'>
               <MainPageEmotionList

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -128,13 +128,13 @@ export default function Epigrams() {
           </div>
           {isEmotionSaved ? (
             selectedEmotion && (
-              <div className='ml-15 mt-10 flex w-640'>
+              <div className='ml-15 mt-10 flex w-314 md:w-384 xl:w-640'>
                 <MainPageEmotionCard
                   emotionType={selectedEmotion}
                   isSelected={true}
                   handleCardClick={() => {}}
                 />
-                <p className='flex justify-items-center whitespace-pre-wrap pl-20 font-secondary text-20'>
+                <p className='flex justify-items-center whitespace-pre-wrap pl-20 pt-5 font-secondary text-14 xl:text-18'>
                   {selectedEmotion === 'MOVED' &&
                     `감동이 가득한 하루였군요!\n작은 순간 하나하나가 당신에게 깊은 울림이 되었길 바랍니다.\n앞으로도 많은 감동이 함께하길 응원할게요! `}
                   {selectedEmotion === 'HAPPY' &&

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -19,6 +19,7 @@ export default function Epigrams() {
   );
   const [isLoadingTodayEpigram, setIsLoadingTodayEpigram] = useState(true);
   const [isLoadingEpigrams, setIsLoadingEpigrams] = useState(true);
+  const [isLoadingComments, setIsLoadingComments] = useState(true);
 
   //최신 댓글 불러오기
   const {

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -1,6 +1,7 @@
 import { useComments } from '@/api/comments/useComments';
 import Plus from '@/assets/icons/ic-plus.svg';
 import Button from '@/components/Button';
+import { postEmotionLogsToday } from '@/lib/api/emotionLogs';
 import { fetchEpigramCards, fetchTodayEpigram } from '@/lib/api/getEpigramCard';
 import Comment from '@/shared/Comment/Comment';
 import EmotionList from '@/shared/EmotionList';
@@ -9,6 +10,7 @@ import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import { useEffect, useState } from 'react';
 
+import MainPageEmotionList from './MainPageEmotionList';
 import { SkeletonCard } from './skeleton';
 
 export default function Epigrams() {
@@ -17,6 +19,8 @@ export default function Epigrams() {
   const [todayEpigram, setTodayEpigram] = useState<EpigramListType | null>(
     null
   );
+  const [selectedEmotion, setSelectedEmotion] = useState<Emotion | null>(null);
+  const [isEmotionSaved, setIsEmotionSaved] = useState(false);
   const [isLoadingTodayEpigram, setIsLoadingTodayEpigram] = useState(true);
   const [isLoadingEpigrams, setIsLoadingEpigrams] = useState(true);
   const [isLoadingComments, setIsLoadingComments] = useState(true);
@@ -28,6 +32,26 @@ export default function Epigrams() {
     loadMore: loadMoreComments,
     hasMore: hasMoreComments,
   } = useComments(10);
+
+  // 에피그램 더보기
+  const handleLoadMore = () => {
+    setVisibleCount(prevCount => prevCount + 4);
+  };
+
+  //오늘의 감정 선택하기
+  const handleSaveEmotion = async () => {
+    if (selectedEmotion) {
+      await postEmotionLogsToday({ emotion: selectedEmotion });
+      console.log(`오늘의 감정: ${selectedEmotion}`);
+      setIsEmotionSaved(true);
+    }
+  };
+
+  //다시 고르기 버튼 클릭 핸들러
+  const handleChooseAgain = () => {
+    setIsEmotionSaved(false); // 상태 초기화
+    setSelectedEmotion(null); // 선택된 감정 초기화
+  };
 
   useEffect(() => {
     const loadEpigrams = async () => {
@@ -56,11 +80,6 @@ export default function Epigrams() {
 
     loadEpigrams();
   }, []);
-
-  // 에피그램 더보기
-  const handleLoadMore = () => {
-    setVisibleCount(prevCount => prevCount + 4);
-  };
 
   return (
     <div className='flex h-full w-full justify-center bg-background-100'>
@@ -91,12 +110,38 @@ export default function Epigrams() {
             <h1 className='mb-24 font-primary text-16 font-semibold xl:mb-40 xl:text-24'>
               오늘의 감정은 어떤가요?
             </h1>
-            <button className='h-full w-100 bg-black-100'>감정 저장하기</button>
+            <div className='flex items-center'>
+              <button
+                className='h-full w-fit cursor-pointer rounded-md bg-illust-yellow p-8 font-primary font-semibold duration-100 hover:scale-105'
+                onClick={handleSaveEmotion}
+              >
+                감정 저장하기
+              </button>
+              <button
+                className='bg-illust-gray ml-4 h-full w-fit cursor-pointer rounded-md p-8 font-primary font-semibold duration-100 hover:scale-105'
+                onClick={handleChooseAgain} // 다시 고르기 버튼 클릭 핸들러
+              >
+                다시 고르기
+              </button>
+            </div>
           </div>
-
-          <div className='flex-center'>
-            <EmotionList />
-          </div>
+          {isEmotionSaved ? (
+            <div className='mt-4 flex items-center'>
+              <EmotionCard
+                emotionType={selectedEmotion}
+                isSelected={true}
+                handleCardClick={() => {}}
+              />
+              <p className='ml-4 text-xl'>{selectedEmotion}한 하루였군요</p>
+            </div>
+          ) : (
+            <div className='flex-center'>
+              <MainPageEmotionList
+                selectedEmotion={selectedEmotion}
+                setSelectedEmotion={setSelectedEmotion}
+              />
+            </div>
+          )}
         </div>
         <div className='mt-56 xl:mt-140'>
           <h1 className='mb-24 font-primary text-16 font-semibold xl:mb-40 xl:text-24'>

--- a/src/pages/epigrams/index.tsx
+++ b/src/pages/epigrams/index.tsx
@@ -9,7 +9,7 @@ import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
 import { useEffect, useState } from 'react';
 
-import { SkeletonCard } from './skeleton';
+import SkeletonCard from '../feed/skeletonCard';
 
 export default function Epigrams() {
   const [cards, setCards] = useState<EpigramListType[]>([]);

--- a/src/pages/epigrams/mainPageEmotionList/components/EmotionCard.tsx
+++ b/src/pages/epigrams/mainPageEmotionList/components/EmotionCard.tsx
@@ -1,0 +1,80 @@
+import IconAngry from '@/assets/icons/ic-emotion-angry.svg';
+import IconHappy from '@/assets/icons/ic-emotion-happy.svg';
+import IconMoved from '@/assets/icons/ic-emotion-moved.svg';
+import IconSad from '@/assets/icons/ic-emotion-sad.svg';
+import IconWorried from '@/assets/icons/ic-emotion-worried.svg';
+
+const iconSize = 'w-32 h-32 xl:w-48 xl:h-48';
+const dataByEmotionType = {
+  MOVED: {
+    name: '감동',
+    render: <IconMoved className={iconSize} />,
+    borderColor: 'border-illust-yellow',
+  },
+  HAPPY: {
+    name: '기쁨',
+    render: <IconHappy className={iconSize} />,
+    borderColor: 'border-illust-green',
+  },
+  WORRIED: {
+    name: '고민',
+    render: <IconWorried className={iconSize} />,
+    borderColor: 'border-illust-purple',
+  },
+  SAD: {
+    name: '슬픔',
+    render: <IconSad className={iconSize} />,
+    borderColor: 'border-illust-blue',
+  },
+  ANGRY: {
+    name: '분노',
+    render: <IconAngry className={iconSize} />,
+    borderColor: 'border-illust-red',
+  },
+};
+
+interface EmotionCardProps {
+  emotionType: Emotion;
+  isSelected?: boolean;
+  handleCardClick: (emotion: Emotion) => void;
+}
+
+export default function EmotionCard({
+  emotionType,
+  isSelected,
+  handleCardClick,
+}: EmotionCardProps) {
+  const emotionData = dataByEmotionType[emotionType];
+
+  const borderBase = 'border-3 xl:border-4 border-solid ';
+  const borderColor = emotionData.borderColor;
+  const selectedBorder = isSelected ? borderBase + borderColor : '';
+
+  const padding = isSelected ? 'p-9 md:p-13 xl:p-20' : 'p-12 md:p-16 xl:p-24';
+  const backgroundColor = isSelected ? '' : 'bg-etc-emotion-background';
+  const textColor = isSelected
+    ? 'text-illust-sub-blue01'
+    : 'text-etc-emotion-textNotSelected';
+
+  const handleClick = () => {
+    handleCardClick(emotionType);
+  };
+
+  return (
+    <div
+      className={`flex w-56 flex-col gap-8 md:w-64 xl:w-96`}
+      onClick={handleClick}
+    >
+      <div
+        className={`box-border w-56 md:w-64 xl:w-96 ${padding} ${selectedBorder} rounded-2xl ${backgroundColor}`}
+      >
+        {emotionData.render}
+      </div>
+      <p
+        className={`text-center font-primary text-12 font-semibold md:text-14 xl:text-24 ${textColor}`}
+      >
+        {emotionData.name}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/epigrams/mainPageEmotionList/components/MainPageEmotionCard.tsx
+++ b/src/pages/epigrams/mainPageEmotionList/components/MainPageEmotionCard.tsx
@@ -39,7 +39,7 @@ interface EmotionCardProps {
   handleCardClick: (emotion: Emotion) => void;
 }
 
-export default function EmotionCard({
+export default function MainPageEmotionCard({
   emotionType,
   isSelected,
   handleCardClick,
@@ -62,7 +62,7 @@ export default function EmotionCard({
 
   return (
     <div
-      className={`flex w-56 flex-col gap-8 md:w-64 xl:w-96`}
+      className={`flex w-56 cursor-pointer flex-col gap-8 duration-100 hover:scale-105 md:w-64 xl:w-96`}
       onClick={handleClick}
     >
       <div

--- a/src/pages/epigrams/mainPageEmotionList/components/MainPageEmotionCard.tsx
+++ b/src/pages/epigrams/mainPageEmotionList/components/MainPageEmotionCard.tsx
@@ -46,6 +46,11 @@ export default function MainPageEmotionCard({
 }: EmotionCardProps) {
   const emotionData = dataByEmotionType[emotionType];
 
+  // emotionData가 undefined인 경우 기본값 설정
+  if (!emotionData) {
+    return null; // 혹은 에러 처리 로직
+  }
+
   const borderBase = 'border-3 xl:border-4 border-solid ';
   const borderColor = emotionData.borderColor;
   const selectedBorder = isSelected ? borderBase + borderColor : '';

--- a/src/pages/epigrams/mainPageEmotionList/index.tsx
+++ b/src/pages/epigrams/mainPageEmotionList/index.tsx
@@ -1,0 +1,42 @@
+import { getEmotionLogsToday } from '@/lib/api/emotionLogs';
+import { useEffect, useState } from 'react';
+
+import EmotionCard from './components/EmotionCard';
+
+const emotionList: Emotion[] = ['MOVED', 'HAPPY', 'WORRIED', 'SAD', 'ANGRY'];
+
+interface EmotionListProps {
+  selectedEmotion: Emotion | null; //부모에서 선택된 감정 받기
+  setSelectedEmotion: (emotion: Emotion | null) => void; //부모에서 상태 변경 함수 받기
+}
+
+export default function MainPageEmotionList({
+  selectedEmotion,
+  setSelectedEmotion,
+}: EmotionListProps) {
+  useEffect(() => {
+    const fetchEmotionLogs = async () => {
+      const result = await getEmotionLogsToday();
+      setSelectedEmotion(result.emotion); //초기값 설정
+    };
+
+    fetchEmotionLogs();
+  }, [setSelectedEmotion]);
+
+  const handleCardClick = (emotion: Emotion) => {
+    setSelectedEmotion(emotion);
+  };
+
+  return (
+    <div className={`flex gap-16`}>
+      {emotionList.map(emotion => (
+        <EmotionCard
+          key={emotion}
+          emotionType={emotion}
+          isSelected={emotion === selectedEmotion}
+          handleCardClick={handleCardClick}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/epigrams/mainPageEmotionList/index.tsx
+++ b/src/pages/epigrams/mainPageEmotionList/index.tsx
@@ -1,13 +1,16 @@
-import { getEmotionLogsToday } from '@/lib/api/emotionLogs';
+import {
+  getEmotionLogsToday,
+  postEmotionLogsToday,
+} from '@/lib/api/emotionLogs';
 import { useEffect, useState } from 'react';
 
-import EmotionCard from './components/EmotionCard';
+import MainPageEmotionCard from './components/MainPageEmotionCard';
 
 const emotionList: Emotion[] = ['MOVED', 'HAPPY', 'WORRIED', 'SAD', 'ANGRY'];
 
 interface EmotionListProps {
-  selectedEmotion: Emotion | null; //부모에서 선택된 감정 받기
-  setSelectedEmotion: (emotion: Emotion | null) => void; //부모에서 상태 변경 함수 받기
+  selectedEmotion: Emotion | null; // 부모에서 선택된 감정을 받아오기
+  setSelectedEmotion: (emotion: Emotion | null) => void; // 부모에서 상태 변경 함수 받아오기
 }
 
 export default function MainPageEmotionList({
@@ -17,7 +20,7 @@ export default function MainPageEmotionList({
   useEffect(() => {
     const fetchEmotionLogs = async () => {
       const result = await getEmotionLogsToday();
-      setSelectedEmotion(result.emotion); //초기값 설정
+      setSelectedEmotion(result.emotion); // 초기값 설정
     };
 
     fetchEmotionLogs();
@@ -30,7 +33,7 @@ export default function MainPageEmotionList({
   return (
     <div className={`flex gap-16`}>
       {emotionList.map(emotion => (
-        <EmotionCard
+        <MainPageEmotionCard
           key={emotion}
           emotionType={emotion}
           isSelected={emotion === selectedEmotion}

--- a/src/pages/epigrams/skeleton.tsx
+++ b/src/pages/epigrams/skeleton.tsx
@@ -2,7 +2,7 @@ export function SkeletonCard() {
   return (
     <div className='flex-center'>
       <div className='mb-10 animate-pulse'>
-        <div className='mb-8 h-314 w-120 rounded-2xl bg-zinc-200 md:h-146 md:w-384 xl:h-148 xl:w-640'></div>
+        <div className='mb-8 h-120 w-314 rounded-2xl bg-zinc-200 md:h-146 md:w-384 xl:h-148 xl:w-640'></div>
         <div className='ml-auto h-24 w-111 rounded-2xl bg-zinc-200 md:h-26 md:w-126 xl:h-40 xl:w-189'></div>
       </div>
     </div>

--- a/src/pages/epigrams/skeleton.tsx
+++ b/src/pages/epigrams/skeleton.tsx
@@ -1,0 +1,24 @@
+export function SkeletonCard() {
+  return (
+    <div className='flex-center'>
+      <div className='mb-10 animate-pulse'>
+        <div className='mb-8 h-314 w-120 rounded-2xl bg-zinc-200 md:h-146 md:w-384 xl:h-148 xl:w-640'></div>
+        <div className='ml-auto h-24 w-111 rounded-2xl bg-zinc-200 md:h-26 md:w-126 xl:h-40 xl:w-189'></div>
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonComment() {
+  return (
+    <div className='flex-center animate-pulse'>
+      <div className='flex w-fit border-t-1 border-solid border-zinc-300 pt-35'>
+        <div className='mb-auto mr-16 h-48 w-48 rounded-full bg-zinc-200'></div>
+        <div>
+          <div className='mb-16 h-26 w-148 rounded-lg bg-zinc-200'></div>
+          <div className='h-64 w-528 rounded-lg bg-zinc-200'></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/epigrams/skeleton.tsx
+++ b/src/pages/epigrams/skeleton.tsx
@@ -1,4 +1,4 @@
-export function SkeletonCard() {
+const SkeletonCard = () => {
   return (
     <div className='flex-center'>
       <div className='mb-10 animate-pulse'>
@@ -7,9 +7,9 @@ export function SkeletonCard() {
       </div>
     </div>
   );
-}
+};
 
-export function SkeletonComment() {
+const SkeletonComment = () => {
   return (
     <div className='flex-center animate-pulse'>
       <div className='flex w-fit border-t-1 border-solid border-zinc-300 pt-35'>
@@ -19,6 +19,15 @@ export function SkeletonComment() {
           <div className='h-64 w-528 rounded-lg bg-zinc-200'></div>
         </div>
       </div>
+    </div>
+  );
+};
+
+export default function Skeleton() {
+  return (
+    <div>
+      <SkeletonCard />
+      <SkeletonComment />
     </div>
   );
 }

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -23,7 +23,7 @@ export default function Feed() {
   useEffect(() => {
     const loadEpigrams = async () => {
       setLoading(true); // Start loading
-      const { list: fullEpigrams } = await fetchEpigramCards({ limit: 10 });
+      const { list: fullEpigrams } = await fetchEpigramCards();
       setCards(fullEpigrams);
       setLoading(false); // End loading
     };

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -3,6 +3,7 @@ import Plus from '@/assets/icons/ic-plus.svg';
 import SortSingle from '@/assets/icons/ic-sort.svg';
 import Button from '@/components/Button';
 import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
+import { fetchEpigramCards } from '@/lib/api/getEpigramCard';
 import EpigramCard from '@/shared/EpigramCard';
 import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';
 import PageUpButton from '@/shared/RightFixedButton/PageUpButton';
@@ -11,35 +12,6 @@ import { useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import SkeletonCard from './skeletonCard';
-
-interface BasicQuery {
-  limit?: number;
-}
-
-// 에피그램 카드 불러오기
-const fetchEpigramCards = async ({ limit }: BasicQuery) => {
-  try {
-    const data = await apiRequestWithAtuh({
-      endpoint: `/epigrams?limit=${limit}`,
-      method: 'GET',
-    });
-
-    return {
-      list: data.list.map((epigramCard: any) => ({
-        id: epigramCard.id,
-        content: epigramCard.content,
-        author: epigramCard.author,
-        tags: Array.isArray(epigramCard.tags)
-          ? epigramCard.tags.map((tag: any) => tag.name)
-          : [],
-      })),
-      totalCount: data.totalCount,
-    };
-  } catch (error) {
-    console.error('에피그램 가져오기 실패:', error);
-    return { list: [], totalCount: 0 };
-  }
-};
 
 export default function Feed() {
   const [cards, setCards] = useState<EpigramListType[]>([]);

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -2,7 +2,6 @@ import SortDouble from '@/assets/icons/ic-dashboard.svg';
 import Plus from '@/assets/icons/ic-plus.svg';
 import SortSingle from '@/assets/icons/ic-sort.svg';
 import Button from '@/components/Button';
-import { apiRequestWithAtuh } from '@/lib/api/apiRequestWithAtuh';
 import { fetchEpigramCards } from '@/lib/api/getEpigramCard';
 import EpigramCard from '@/shared/EpigramCard';
 import AddEpigramButton from '@/shared/RightFixedButton/AddEpigramButton';


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 메인페이지에서 사용되는 '오늘의 감정' Select부분 작업했습니다 
* EmotionCard를 선택한 후 감정 저장하기 버튼을 클릭하면, 선택된 감정 값이 post되고, 조건부 렌더링됩니다
* 일단 임시로 EmotionList를 하나 더 만들어서 작업했습니다. 나중에 리펙토링 시에 shared 폴더의 EmotionList 컴포넌트와 합치도록 하겠습니다🥲

### 스크린샷 (선택)

![emotionSelect](https://github.com/user-attachments/assets/d38796cd-5502-4f46-93f2-1bc4eafa261b)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
